### PR TITLE
cli: fix issue with pointer default values

### DIFF
--- a/cli/handlers.go
+++ b/cli/handlers.go
@@ -23,7 +23,17 @@ func handleRequired(tagMap map[string]string) (required bool, e error) {
 }
 
 func handlePresetValue(field reflect.StructField, value reflect.Value) string {
-	switch field.Type.Kind() {
+	k := field.Type.Kind()
+
+	if k == reflect.Ptr {
+		if value.IsNil() {
+			return ""
+		}
+		k = field.Type.Elem().Kind()
+		value = value.Elem()
+	}
+
+	switch k {
 	case reflect.String:
 		if v := value.String(); v != "" {
 			return v

--- a/cli/option_test.go
+++ b/cli/option_test.go
@@ -118,6 +118,22 @@ func TestPtrOption(t *testing.T) {
 	}
 }
 
+func TestPtrOptionWithPreset(t *testing.T) {
+	s := "test1234"
+	cmd := new(OptionWPtrTestCommand)
+	cmd.Opt = &s
+	a := testCreateAction("test", cmd)
+
+	err := a.reflect()
+	if err != nil {
+		t.Errorf("expected err to be empty, got %s", err)
+	}
+
+	if a.opts[0].value != "test1234" {
+		t.Errorf("expected option default value to be %q, got %q", s, a.opts[0].value)
+	}
+}
+
 type OptionMapTestCommand struct {
 	First  map[string]string `cli:"opt -f --first"`
 	Second map[string]int64  `cli:"opt -s --second"`


### PR DESCRIPTION
For pointer types default values didn't work, as the reflection code
didn't take that into account.