### PR TITLE
cli/logger: replace with explicit print to stderr

### DIFF
--- a/cli/action.go
+++ b/cli/action.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/dynport/dgtk/tagparse"
+	"os"
 )
 
 type action struct {
@@ -275,27 +276,27 @@ func (a *action) reflectArguments() (e error) {
 func (a *action) showHelp() {
 	a.showShortHelp()
 	if a.description != "" {
-		logger.Print("  ", a.description)
+		fmt.Fprintln(os.Stderr, "  ", a.description)
 	}
 
 	optsAvailable := false
 	if len(a.opts) > 0 {
 		optsAvailable = true
-		logger.Print("  OPTIONS")
+		fmt.Fprintln(os.Stderr, "  OPTIONS")
 		for _, opt := range a.opts {
-			logger.Print(opt.description())
+			fmt.Fprintln(os.Stderr, opt.description())
 		}
 	}
 	if len(a.args) > 0 {
 		if optsAvailable {
-			logger.Println()
+			fmt.Fprintln(os.Stderr)
 		}
-		logger.Print("  ARGUMENTS")
+		fmt.Fprintln(os.Stderr, "  ARGUMENTS")
 		for _, arg := range a.args {
-			logger.Print(arg.description())
+			fmt.Fprintln(os.Stderr, arg.description())
 		}
 	}
-	logger.Println()
+	fmt.Fprintln(os.Stderr)
 }
 
 func (a *action) showShortHelp() {
@@ -307,7 +308,7 @@ func (a *action) showShortHelp() {
 		line += arg.shortDescription()
 		line += " "
 	}
-	logger.Print(line)
+	fmt.Fprintln(os.Stderr, line)
 }
 
 func (a *action) showTabularHelp(t *table) {

--- a/cli/basic_example_test.go
+++ b/cli/basic_example_test.go
@@ -1,5 +1,10 @@
 package cli
 
+import (
+	"fmt"
+	"os"
+)
+
 // Struct used to configure an action.
 type ExampleRunner struct {
 	Verbose bool   `cli:"type=opt short=v long=verbose"`               // Flag (boolean option) example. This is either set or not.
@@ -11,7 +16,7 @@ type ExampleRunner struct {
 func (er *ExampleRunner) Run() error {
 	// Called when action matches route.
 	if er.Verbose {
-		logger.Printf("Going to execute %q at the following hosts: %v", er.Command, er.Hosts)
+		fmt.Fprintf(os.Stderr, "Going to execute %q at the following hosts: %v\n", er.Command, er.Hosts)
 	}
 	// [..] Executing the SSH command is left to the reader.
 	return nil

--- a/cli/logger.go
+++ b/cli/logger.go
@@ -1,8 +1,0 @@
-package cli
-
-import (
-	"log"
-	"os"
-)
-
-var logger = log.New(os.Stdout, "", 0)

--- a/cli/router.go
+++ b/cli/router.go
@@ -36,7 +36,8 @@ func NewRouter() *Router {
 // action.
 func (r *Router) Run(args ...string) (e error) {
 	if r.initFailed {
-		logger.Fatal("errors found during initialization")
+		fmt.Fprintln(os.Stderr, "errors found during initialization")
+		os.Exit(1)
 	}
 	// Find action and parse args.
 	node, args := r.findNode(args, true)
@@ -79,7 +80,7 @@ func (r *Router) RegisterFunc(path string, f func() error, desc string) {
 func (r *Router) Register(path string, runner Runner, desc string) {
 	a, e := newAction(path, runner, desc)
 	if e != nil {
-		logger.Printf("%s", e)
+		fmt.Fprintln(os.Stderr, e)
 		r.initFailed = true
 		return
 	}
@@ -88,11 +89,11 @@ func (r *Router) Register(path string, runner Runner, desc string) {
 	node, pathSegments := r.findNode(pathSegments, false)
 	if node != nil {
 		if node.action != nil {
-			logger.Printf("failed to register action for path %q: action for path %q already registered", a.path, node.action.path)
+			fmt.Fprintf(os.Stderr, "failed to register action for path %q: action for path %q already registered\n", a.path, node.action.path)
 			r.initFailed = true
 			return
 		} else if len(pathSegments) == 0 && len(node.children) > 0 {
-			logger.Printf("failed to register action for path %q: longer paths with this prefix exist", a.path)
+			fmt.Fprintf(os.Stderr, "failed to register action for path %q: longer paths with this prefix exist\n", a.path)
 			r.initFailed = true
 			return
 		}
@@ -125,7 +126,7 @@ func (rt *routingTreeNode) showHelp() {
 	} else {
 		t := &table{}
 		rt.showTabularHelp(t)
-		fmt.Println(t)
+		fmt.Fprintln(os.Stderr, t)
 	}
 }
 


### PR DESCRIPTION
Trying to test a CLI application (want to verify default handling works
properly) and failed to do so, due to the logger. I couldn't fetch the
output. This is because the logger is created on test run init (it's an
internal global), but changing the stdout file-descriptor happens during
testing.

Additionally help output is now sent to stderr (instead of stdout). This
is where help text should reside.